### PR TITLE
Fixes #27. Allow default request user agent from header

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.assertj:assertj-core:3.13.0'
 }
 
 task unpack(type: Copy) {

--- a/checker/src/main/java/com/fooock/robotstxt/api/ApiApplication.java
+++ b/checker/src/main/java/com/fooock/robotstxt/api/ApiApplication.java
@@ -2,16 +2,10 @@ package com.fooock.robotstxt.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
  *
  */
-@EntityScan("com.fooock.robotstxt")
-@EnableJpaRepositories("com.fooock.robotstxt.database")
-@ComponentScan("com.fooock.robotstxt")
 @SpringBootApplication
 public class ApiApplication {
     public static void main(String[] args) {

--- a/checker/src/main/java/com/fooock/robotstxt/api/config/AppConfiguration.java
+++ b/checker/src/main/java/com/fooock/robotstxt/api/config/AppConfiguration.java
@@ -1,0 +1,17 @@
+package com.fooock.robotstxt.api.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * Configure application dependencies
+ */
+@EntityScan("com.fooock.robotstxt")
+@EnableJpaRepositories("com.fooock.robotstxt.database")
+@ComponentScan("com.fooock.robotstxt")
+@Configuration
+public class AppConfiguration {
+    // See https://github.com/spring-projects/spring-boot/issues/6844
+}

--- a/checker/src/main/java/com/fooock/robotstxt/api/controller/ApiController.java
+++ b/checker/src/main/java/com/fooock/robotstxt/api/controller/ApiController.java
@@ -5,7 +5,9 @@ import com.fooock.robotstxt.api.model.AllowResponse;
 import com.fooock.robotstxt.api.service.ApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.validation.Valid;
 
@@ -20,32 +22,55 @@ public class ApiController {
     private final ApiService apiService;
 
     /**
-     * Check if the given URL resource can be accessed with the provided agent.
+     * Check if the given URL resource can be accessed with the provided agent. Note that user agent is
+     * mandatory for this method to retrieve a valid result. User agent can be provided in two different
+     * modes: By request user-agent, or user defined agent. If the user agent param from the {@link AllowData}
+     * class is not present, then the {@code user-agent} request header will be used, but if these header is
+     * not set, the request will thrown an exception.
      *
-     * @param data Data to be checked
+     * @param agent Request default user agent. This field is not required to be present when the agent from
+     *              the {@code data} params is present.
+     * @param data  Data to be checked
      * @return An object with the data sent and a flag to indicate if the resource can be accessed or not
      */
     @PostMapping("allowed")
-    public AllowResponse isAllowed(@RequestBody @Valid AllowData data) {
+    public AllowResponse isAllowed(@RequestHeader(value = "user-agent", required = false) String agent,
+                                   @RequestBody @Valid AllowData data) {
+        if ((agent == null || agent.isEmpty()) && !data.isAgentValid())
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "user-agent is not provided");
+        if (!data.isAgentValid()) data.setAgent(agent);
+
         log.debug("[POST] Called method isAllowed to check resource {}", data.toString());
         return apiService.isAllowed(data);
     }
 
     /**
-     * Check if the given URL resource can be accessed with the provided agent.
+     * Check if the given URL resource can be accessed with the provided agent. Note that user agent is
+     * mandatory for this method to retrieve a valid result. User agent can be provided in two different
+     * modes: By request user-agent, or user defined agent. If the user agent param from the {@link AllowData}
+     * class is not present, then the {@code user-agent} request header will be used, but if these header is not
+     * set, the request will thrown an exception.
      *
-     * @param url   Url to check
-     * @param agent Agent name
+     * @param requestAgent Request default user agent. Can be empty
+     * @param url          Url to check. Can't be empty.
+     * @param agent        Agent name. Can be empty.
      * @return An object with the data sent and a flag to indicate if the resource can be accessed or not
      */
-    @GetMapping(value = "allowed", params = {"url", "agent"})
-    public AllowResponse isAllowed(@RequestParam("url") String url, @RequestParam("agent") String agent) {
-        log.debug("[GET] Called method isAllowed with url {} and user agent {}", url, agent);
-
+    @GetMapping("allowed")
+    public AllowResponse isAllowed(@RequestHeader(value = "user-agent", required = false) String requestAgent,
+                                   @RequestParam("url") String url,
+                                   @RequestParam(value = "agent", required = false) String agent) {
+        // Create object with default data
         AllowData data = new AllowData();
         data.setAgent(agent);
         data.setUrl(url);
 
+        // Validate provided user agent
+        if ((requestAgent == null || requestAgent.isEmpty()) && !data.isAgentValid())
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "user-agent is not provided");
+        if (!data.isAgentValid()) data.setAgent(requestAgent);
+
+        log.debug("[GET] Called method isAllowed with url {} and user agent {}", url, agent);
         return apiService.isAllowed(data);
     }
 }

--- a/checker/src/main/java/com/fooock/robotstxt/api/model/AllowData.java
+++ b/checker/src/main/java/com/fooock/robotstxt/api/model/AllowData.java
@@ -17,7 +17,12 @@ public class AllowData implements Serializable {
 
     @NotEmpty(message = "URL cannot be empty or null")
     private String url;
-
-    @NotEmpty(message = "User agent cannot be null or empty")
     private String agent;
+
+    /**
+     * @return True if agent is not null or empty, false otherwise.
+     */
+    public boolean isAgentValid() {
+        return agent != null && !agent.isEmpty();
+    }
 }

--- a/checker/src/test/java/com/fooock/robotstxt/api/HttpRequestTest.java
+++ b/checker/src/test/java/com/fooock/robotstxt/api/HttpRequestTest.java
@@ -1,0 +1,117 @@
+package com.fooock.robotstxt.api;
+
+import com.fooock.robotstxt.api.controller.ApiController;
+import com.fooock.robotstxt.api.model.AllowData;
+import com.fooock.robotstxt.api.service.ApiService;
+import com.google.gson.Gson;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+/**
+ *
+ */
+@RunWith(SpringRunner.class)
+@WebMvcTest(ApiController.class)
+public class HttpRequestTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ApiService apiService;
+    private Gson gson = new Gson();
+
+    @Test
+    public void testPostRequestWithoutAgent() throws Exception {
+        AllowData data = new AllowData();
+        data.setUrl("http://example.com/test/user");
+        data.setAgent("");
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/v1/allowed")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(data))
+                .header("user-agent", "");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().is(400));
+    }
+
+    @Test
+    public void testPostRequestWithRequestAgent() throws Exception {
+        AllowData data = new AllowData();
+        data.setUrl("http://example.com/test/user");
+        data.setAgent("");
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/v1/allowed")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(data))
+                .header("user-agent", "AwesomeBot");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().is(200));
+    }
+
+    @Test
+    public void testPostRequestWithDataAgent() throws Exception {
+        AllowData data = new AllowData();
+        data.setUrl("http://example.com/test/user");
+        data.setAgent("AwesomeBot");
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/v1/allowed")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(data))
+                .header("user-agent", "");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().is(200));
+    }
+
+    @Test
+    public void testGetRequestWithoutAgent() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v1/allowed")
+                .param("url", "http://example.com/test/user")
+                .header("user-agent", "");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().is(400));
+    }
+
+    @Test
+    public void testGetRequestWithoutAgentAndUrl() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v1/allowed")
+                .param("url", "")
+                .header("user-agent", "");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().is(400));
+    }
+
+    @Test
+    public void testGetRequestWithRequestAgent() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v1/allowed")
+                .param("url", "http://example.com/test/user")
+                .header("user-agent", "AwesomeBot");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().is(200));
+    }
+
+    @Test
+    public void testGetRequestWithParamAgent() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v1/allowed")
+                .param("url", "http://example.com/test/user")
+                .param("agent", "AwesomeBot");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().is(200));
+    }
+}

--- a/checker/src/test/java/com/fooock/robotstxt/api/model/AllowDataTest.java
+++ b/checker/src/test/java/com/fooock/robotstxt/api/model/AllowDataTest.java
@@ -1,0 +1,27 @@
+package com.fooock.robotstxt.api.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class AllowDataTest {
+
+    @Test
+    public void testAgent() {
+        AllowData d1 = new AllowData();
+        d1.setAgent(null);
+        assertFalse(d1.isAgentValid());
+
+        AllowData d2 = new AllowData();
+        d2.setAgent("");
+        assertFalse(d2.isAgentValid());
+
+        AllowData d3 = new AllowData();
+        d3.setAgent("AwesomeBot");
+        assertTrue(d3.isAgentValid());
+    }
+}


### PR DESCRIPTION
Allow empty agent field from data payload in the `/v1/allowed` call requests and try to use default request user-agent if possible. If no user agent found, then an exception is thrown